### PR TITLE
Update variables to reflect proper trigger data for the Rate Limit Exceeded event

### DIFF
--- a/src/effects/check.ts
+++ b/src/effects/check.ts
@@ -367,9 +367,9 @@ export const checkEffect: Firebot.EffectType<effectModel> = {
                 messageId: trigger.metadata.chatMessage?.id || "",
                 metadataKey: effect.rateLimitMetadata || "",
                 next: checkResult.next,
-                originalEventId: trigger.metadata.event?.id || "",
-                originalEventSourceId: trigger.metadata.eventSource?.id || "",
-                originalUsername: typeof trigger.metadata.eventData?.originalUsername === "string"
+                triggerMetadata: trigger.metadata || {},
+                triggerType: trigger.type || "",
+                triggerUsername: typeof trigger.metadata.eventData?.originalUsername === "string"
                     ? trigger.metadata.eventData.originalUsername
                     : (typeof trigger.metadata.eventData?.username === "string"
                         ? trigger.metadata.eventData.username

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -78,9 +78,9 @@ export type LimitExceededEventMetadata = {
     messageId: string; // ID of the chat message that triggered the check
     metadataKey: string; // Key used to store metadata in the event
     next: number; // Seconds until next available token
-    originalEventId: string; // ID of the original event that triggered the check
-    originalEventSourceId: string; // ID of the original event source
-    originalUsername: string; // Username from the original event source if tracked
+    triggerMetadata: Record<string, any>; // Original event data that triggered the check
+    triggerType: string; // Type of the original event source
+    triggerUsername: string; // Username from the original event source if tracked
     rejectReason?: RejectReason; // Reason for rejection if not successful
     remaining: number; // Remaining invocations allowed after the request
     stackDepth: number; // Prevents infinite loops in event triggering

--- a/src/variables/index.ts
+++ b/src/variables/index.ts
@@ -5,10 +5,12 @@ import { rateLimitInvocationLimit } from './invocation-limit';
 import { rateLimitMessageId } from './message-id';
 import { rateLimitMetadataKey } from './metadata-key';
 import { rateLimitNext } from './next';
-import { rateLimitOriginalUsername } from './original-username';
 import { rateLimitRawObject } from './raw-object';
 import { rateLimitRejectReason } from './reason';
 import { rateLimitRemaining } from './remaining';
+import { rateLimitTriggerMetadata } from './trigger-metadata';
+import { rateLimitTriggerType } from './trigger-type';
+import { rateLimitTriggerUsername } from './trigger-username';
 
 export function registerReplaceVariables() {
     const { replaceVariableManager } = firebot.modules;
@@ -19,7 +21,9 @@ export function registerReplaceVariables() {
     replaceVariableManager.registerReplaceVariable(rateLimitMessageId);
     replaceVariableManager.registerReplaceVariable(rateLimitMetadataKey);
     replaceVariableManager.registerReplaceVariable(rateLimitNext);
-    replaceVariableManager.registerReplaceVariable(rateLimitOriginalUsername);
+    replaceVariableManager.registerReplaceVariable(rateLimitTriggerMetadata);
+    replaceVariableManager.registerReplaceVariable(rateLimitTriggerType);
+    replaceVariableManager.registerReplaceVariable(rateLimitTriggerUsername);
     replaceVariableManager.registerReplaceVariable(rateLimitRawObject);
     replaceVariableManager.registerReplaceVariable(rateLimitRejectReason);
     replaceVariableManager.registerReplaceVariable(rateLimitRemaining);

--- a/src/variables/trigger-metadata.ts
+++ b/src/variables/trigger-metadata.ts
@@ -1,0 +1,19 @@
+import { Effects } from '@crowbartools/firebot-custom-scripts-types/types/effects';
+import { ReplaceVariable } from '@crowbartools/firebot-custom-scripts-types/types/modules/replace-variable-manager';
+import { LimitExceededEventMetadata } from '../shared/types';
+
+export const rateLimitTriggerMetadata: ReplaceVariable = {
+    definition: {
+        handle: "rateLimitTriggerMetadata",
+        description: "Returns the metadata of the original event that triggered the rate limit check.",
+        possibleDataOutput: ["object"],
+        triggers: {
+            "manual": true,
+            "event": ['rate-limiter:limit-exceeded']
+        }
+    },
+    evaluator: async (trigger: Effects.Trigger) => {
+        const eventData = trigger.metadata?.eventData as LimitExceededEventMetadata | undefined;
+        return eventData?.triggerMetadata || {};
+    }
+};

--- a/src/variables/trigger-type.ts
+++ b/src/variables/trigger-type.ts
@@ -1,12 +1,11 @@
 import { Effects } from '@crowbartools/firebot-custom-scripts-types/types/effects';
 import { ReplaceVariable } from '@crowbartools/firebot-custom-scripts-types/types/modules/replace-variable-manager';
-import { logger } from '../main';
 import { LimitExceededEventMetadata } from '../shared/types';
 
-export const rateLimitOriginalUsername: ReplaceVariable = {
+export const rateLimitTriggerType: ReplaceVariable = {
     definition: {
-        handle: "rateLimitOriginalUsername",
-        description: "Returns the username of the user making the request that was rate limited.",
+        handle: "rateLimitTriggerType",
+        description: "Returns the type of the original event that triggered the rate limit check.",
         possibleDataOutput: ["text"],
         triggers: {
             "manual": true,
@@ -15,10 +14,6 @@ export const rateLimitOriginalUsername: ReplaceVariable = {
     },
     evaluator: async (trigger: Effects.Trigger) => {
         const eventData = trigger.metadata?.eventData as LimitExceededEventMetadata | undefined;
-        if (!eventData) {
-            logger.warn('Called rateLimitOriginalUsername variable without expected metadata.');
-            return "";
-        }
-        return eventData.originalUsername;
+        return eventData?.triggerType || "";
     }
 };

--- a/src/variables/trigger-username.ts
+++ b/src/variables/trigger-username.ts
@@ -1,0 +1,19 @@
+import { Effects } from '@crowbartools/firebot-custom-scripts-types/types/effects';
+import { ReplaceVariable } from '@crowbartools/firebot-custom-scripts-types/types/modules/replace-variable-manager';
+import { LimitExceededEventMetadata } from '../shared/types';
+
+export const rateLimitTriggerUsername: ReplaceVariable = {
+    definition: {
+        handle: "rateLimitTriggerUsername",
+        description: "Returns the username from the original event source that triggered the rate limit check.",
+        possibleDataOutput: ["text"],
+        triggers: {
+            "manual": true,
+            "event": ['rate-limiter:limit-exceeded']
+        }
+    },
+    evaluator: async (trigger: Effects.Trigger) => {
+        const eventData = trigger.metadata?.eventData as LimitExceededEventMetadata | undefined;
+        return eventData?.triggerUsername || "";
+    }
+};


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
Updates the variables used to communicate the trigger data.

Variables are:

- `$rateLimitTriggerMetadata` (object)
- `$rateLimitTriggerType` (string)
- `$rateLimitTriggerUsername` (string)

### Motivation
The old way was not working properly.

### Testing
Set a rate limit on a channel reward, then redeemed it and examined the variables being written out to chat.
