### PR TITLE
Version bump opens draft PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,11 @@ on:
   pull_request:
     branches:
       - "*"
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
 
 jobs:
   build:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,12 +1,14 @@
 name: Linting
 
 on:
-  push:
-    branches:
-      - "main"
   pull_request:
     branches:
       - "*"
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
 
 jobs:
   lint:

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -56,7 +56,7 @@ jobs:
           body: "This PR bumps the version to ${{ steps.bump_version.outputs.next-version }}."
           branch: "bump-version-${{ steps.bump_version.outputs.next-version }}"
           base: main
-          draft: false
+          draft: always-true
           labels: 'ignore-for-release'
           add-paths: |
             package.json


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
This causes the "version bump" action to open its PRs as drafts, this allowing the CI actions to run when the PR is marked as ready for review

### Motivation
Documented workaround for GitHub actions generated PRs not running CI on themselves.

### Testing
This won't be tested for now since there's not a release to process. However these same changes were implemented in <https://github.com/TheStaticMage/firebot-mage-trivia> and then a release was made.
