### PR TITLE
Add fill across restarts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ node_modules/
 
 # OS
 .DS_Store
+
+# Coverage
+/coverage/

--- a/README.md
+++ b/README.md
@@ -49,16 +49,23 @@ The [tutorial](/doc/tutorial.md) implements the "cookies and marbles" example fr
 
 :bulb: _Many Firebot components support limits. If you can achieve what you need via native Firebot functionality, you generally should. This example is provided for educational purposes only._
 
+### Persist cooldowns across streams / Firebot restarts
+
+:bulb: _I do not believe that Firebot can natively do this._
+
+- Create an advanced bucket in the RATE LIMITER tab from the left frame
+- Check the "Persist bucket data across Firebot restarts" and "Fill across Firebot restarts" boxes.
+
 ### Real-life example: Preventing over-notification of small bits cheers
 
 ### Real-life example: Preventing over-use of TTS
 
 ## Support
 
-The best way to get help is in this project's thread on Discord. Join the [Crowbar Tools Discord](https://discord.gg/crowbartools-372817064034959370) and then visit the [thread for Firebot Rate Limiter]() there.
+The best way to get help is in my Discord server. Join the [The Static Discord](https://discord.gg/hw32MM2Qxq) and then visit the `#firebot-rate-limiter` channel there.
 
-  - Please do not DM me on Discord.
-  - Please do not ask for help in my chat when I am live on Twitch.
+- Please do not DM me on Discord.
+- Please do not ask for help in my chat when I am live on Twitch.
 
 Bug reports and feature requests are welcome via [GitHub Issues](https://github.com/TheStaticMage/firebot-rate-limiter/issues).
 
@@ -73,6 +80,8 @@ This script is released under the [GNU General Public License version 3](/LICENS
 If you use this on your stream, I would appreciate a shout-out. (Appreciated, but not required.)
 
 - <https://www.twitch.tv/thestaticmage>
+- <https://kick.com/thestaticmage>
+- <https://youtube.com/@thestaticmagerisk>
 
 ## FAQ
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
         "build:version": "node ./scripts/update-version.js",
         "build:webpack": "webpack",
         "copy": "node ./scripts/copy-build.js",
-        "prepare": ""
+        "prepare": "",
+        "test": "jest --coverage",
+        "jest": "jest --coverage"
     },
     "author": "thestaticmage",
     "license": "GNU3",

--- a/src/__tests__/dummy.test.ts
+++ b/src/__tests__/dummy.test.ts
@@ -1,5 +1,0 @@
-import { expect, test } from '@jest/globals';
-
-test('dummy test (always passes)', () => {
-    expect(true).toBe(true);
-});

--- a/src/backend/bucket-data.test.ts
+++ b/src/backend/bucket-data.test.ts
@@ -35,61 +35,7 @@ jest.mock('./util', () => ({
     getDataFilePath: jest.fn(() => '/tmp/test-bucket-data.json')
 }));
 
-
 describe('BucketData', () => {
-    it('should not exceed lifetimeMaxTokens when adding tokens', () => {
-        const lifetimeBucket: Bucket = {
-            name: 'lifetime',
-            type: 'simple',
-            maxTokens: 10,
-            refillRate: 100, // high refill rate to test cap
-            startTokens: 5,
-            fillFromStart: false,
-            persistBucket: true,
-            lifetimeMaxTokens: true,
-            lifetimeMaxTokensValue: 7
-        };
-        mockedBucketService.__setBuckets({
-            lifetime: lifetimeBucket
-        });
-        bucketData = new BucketData();
-        // First addTokens should set lifetimeTokenCount to 5
-        let entry = bucketData.addTokens('lifetime', lifetimeBucket, key);
-        expect(entry.lifetimeTokenCount).toBe(5);
-        // Simulate time passing to try to add more tokens
-        jest.setSystemTime(now + 10000); // 10 seconds
-        entry = bucketData.addTokens('lifetime', lifetimeBucket, key);
-        // Should not exceed lifetimeMaxTokensValue (7)
-        expect(entry.lifetimeTokenCount).toBeLessThanOrEqual(7);
-    });
-
-    it('should initialize with fillFromStart tokens', () => {
-        const fillBucket: Bucket = {
-            name: 'fill',
-            type: 'simple',
-            maxTokens: 20,
-            refillRate: 2, // 2 tokens/sec
-            startTokens: 0,
-            fillFromStart: true,
-            persistBucket: true,
-            lifetimeMaxTokens: false,
-            lifetimeMaxTokensValue: 0
-        };
-        mockedBucketService.__setBuckets({
-            fill: fillBucket
-        });
-        // Simulate 5 seconds since start
-        const fiveSecondsAgo = now;
-        const nowPlus5s = now + 5000;
-        jest.setSystemTime(nowPlus5s);
-        bucketData = new BucketData(fiveSecondsAgo);
-        // The first addTokens should initialize with fillTokens = refillRate * (now - startTime) / 1000
-        // But since startTokens is 0, should be 2 * 5 = 10 tokens
-        const entry = bucketData.addTokens('fill', fillBucket, key);
-        expect(entry.tokenCount).toBe(10);
-        expect(entry.lifetimeTokenCount).toBe(10);
-    });
-    let bucketData: BucketData;
     const bucketId = 'bucket1';
     const key = 'user1';
     const now = Date.now();
@@ -102,6 +48,7 @@ describe('BucketData', () => {
         startTokens: 5,
         fillFromStart: false,
         persistBucket: true,
+        fillBucketAcrossRestarts: false,
         lifetimeMaxTokens: false,
         lifetimeMaxTokensValue: 0
     };
@@ -115,7 +62,6 @@ describe('BucketData', () => {
         mockedBucketService.__setBuckets({
             [bucketId]: bucket
         });
-        bucketData = new BucketData();
     });
 
     afterEach(() => {
@@ -123,153 +69,270 @@ describe('BucketData', () => {
         jest.useRealTimers();
     });
 
-    it('should initialize and load empty data', () => {
-        expect(bucketData.getAllBucketData(bucketId)).toEqual({});
-    });
+    describe('parseFileData', () => {
+        // Test-only subclass to expose private parseFileData
+        class TestableBucketData extends BucketData {
+            public parseFileDataPublic(data: string) {
+            // @ts-expect-error: access private method for testing
+                return this.parseFileData(data);
+            }
+        }
 
-    it('should add tokens and update bucket data', () => {
-        const entry = bucketData.addTokens(bucketId, bucket, key);
-        expect(entry.tokenCount).toBe(bucket.startTokens);
-        expect(entry.lifetimeTokenCount).toBe(bucket.startTokens);
-        expect(entry.invocationCount).toBe(0);
-        expect(typeof entry.lastUpdated).toBe('number');
-    });
+        it('should correctly parse file data with and without fillBucketAcrossRestarts', () => {
+            // Mock getBucket to return buckets with and without fillBucketAcrossRestarts
+            const testBucketId1 = 'bucket1';
+            const testBucketId2 = 'bucket2';
+            const entry = {
+                tokenCount: 5,
+                lifetimeTokenCount: 5,
+                lastUpdated: 12345,
+                invocationCount: 2
+            };
 
-    it('should check and allow if enough tokens', () => {
-        const request: CheckRateLimitRequest = {
-            bucketId,
-            bucketType: 'simple',
-            key,
-            tokenRequest: 2,
-            inquiry: false,
-            bucketSize: 10,
-            bucketRate: 1,
-            invocationLimit: false,
-            invocationLimitValue: 0
-        };
-        const res = bucketData.check(request);
-        expect(res.success).toBe(true);
-        expect(res.remaining).toBe(-1);
-        expect(res.invocation).toBe(1);
-    });
+            mockedBucketService.__setBuckets({
+                [testBucketId1]: { fillBucketAcrossRestarts: true },
+                [testBucketId2]: { fillBucketAcrossRestarts: false }
+            });
 
-    it('should check and reject if not enough tokens', () => {
-        // Use up all tokens
-        const request: CheckRateLimitRequest = {
-            bucketId,
-            bucketType: 'simple',
-            key,
-            tokenRequest: 10,
-            inquiry: false,
-            bucketSize: 10,
-            bucketRate: 1,
-            invocationLimit: false,
-            invocationLimitValue: 0
-        };
-        bucketData.check(request); // uses 5 tokens
-        bucketData.check(request); // should fail
-        const res = bucketData.check(request);
-        expect(res.success).toBe(false);
-        expect(res.rejectReason).toBe(RejectReason.RateLimit);
-        expect(typeof res.next).toBe('number');
-        expect(res.errorMessage).toMatch(/Insufficient tokens/);
-    });
-
-    it('should check and reject if invocation limit reached', () => {
-        const request: CheckRateLimitRequest = {
-            bucketId,
-            bucketType: 'simple',
-            key,
-            tokenRequest: 1,
-            inquiry: false,
-            bucketSize: 10,
-            bucketRate: 1,
-            invocationLimit: true,
-            invocationLimitValue: 1
-        };
-        bucketData.check(request); // first invocation
-        const res = bucketData.check(request); // should fail
-        expect(res.success).toBe(false);
-        expect(res.rejectReason).toBe(RejectReason.InvocationLimit);
-        expect(res.remaining).toBe(0);
-        expect(res.errorMessage).toMatch(/Invocation limit reached/);
-    });
-
-    it('should delete a key', () => {
-        bucketData.addTokens(bucketId, bucket, key);
-        expect(bucketData.deleteKey(bucketId, key)).toBe(true);
-        expect(bucketData.hasKey(bucketId, key)).toBe(false);
-    });
-
-    it('should return false when deleting non-existent key', () => {
-        expect(bucketData.deleteKey(bucketId, 'notfound')).toBe(false);
-    });
-
-    it('should list keys', () => {
-        bucketData.addTokens(bucketId, bucket, key);
-        expect(bucketData.listKeys(bucketId)).toContain(key);
-    });
-
-    it('should set key data', () => {
-        bucketData.addTokens(bucketId, bucket, key);
-        const newData: BucketDataEntry = {
-            tokenCount: 2,
-            lifetimeTokenCount: 2,
-            lastUpdated: now,
-            invocationCount: 1
-        };
-        bucketData.setKey(bucketId, key, newData);
-        expect(bucketData.getAllBucketData(bucketId)[key]).toEqual(newData);
-    });
-
-    it('should not set key for non-existent bucket', () => {
-        const spy = jest.spyOn(require('../main').logger, 'error');
-        bucketData.setKey('notfound', key, {
-            tokenCount: 1,
-            lifetimeTokenCount: 1,
-            lastUpdated: now,
-            invocationCount: 0
+            const data = JSON.stringify({
+                [testBucketId1]: { user1: { ...entry } },
+                [testBucketId2]: { user2: { ...entry } }
+            });
+            const tbd = new TestableBucketData();
+            const result = tbd.parseFileDataPublic(data);
+            // bucket1 should keep lastUpdated, bucket2 should set lastUpdated to 0
+            expect(result[testBucketId1].user1.lastUpdated).toBe(12345);
+            expect(result[testBucketId2].user2.lastUpdated).toBe(0);
         });
-        expect(spy).toHaveBeenCalled();
     });
 
-    it('should persist only buckets with persistBucket=true', () => {
-        const bucket2: Bucket = {
-            name: 'bucket2',
-            type: 'simple',
-            maxTokens: 10,
-            refillRate: 1,
-            startTokens: 5,
-            fillFromStart: false,
-            persistBucket: false,
-            lifetimeMaxTokens: false,
-            lifetimeMaxTokensValue: 0
-        };
-        mockedBucketService.__setBuckets({
-            [bucketId]: bucket,
-            bucket2
+    describe('addTokens', () => {
+        it('should not exceed lifetimeMaxTokens when adding tokens', () => {
+            const lifetimeBucket: Bucket = {
+                name: 'lifetime',
+                type: 'simple',
+                maxTokens: 10,
+                refillRate: 100, // high refill rate to test cap
+                startTokens: 5,
+                fillFromStart: false,
+                persistBucket: true,
+                fillBucketAcrossRestarts: false,
+                lifetimeMaxTokens: true,
+                lifetimeMaxTokensValue: 7
+            };
+            mockedBucketService.__setBuckets({
+                lifetime: lifetimeBucket
+            });
+            const bucketData = new BucketData();
+            // First addTokens should set lifetimeTokenCount to 5
+            let entry = bucketData.addTokens('lifetime', lifetimeBucket, key);
+            expect(entry.lifetimeTokenCount).toBe(5);
+            // Simulate time passing to try to add more tokens
+            jest.setSystemTime(now + 10000); // 10 seconds
+            entry = bucketData.addTokens('lifetime', lifetimeBucket, key);
+            // Should not exceed lifetimeMaxTokensValue (7)
+            expect(entry.lifetimeTokenCount).toBeLessThanOrEqual(7);
         });
-        bucketData.addTokens(bucketId, bucket, key);
-        bucketData.addTokens('bucket2', bucket2, 'key2');
-        const persistent = (bucketData as any).getPersistentBucketData();
-        expect(Object.keys(persistent)).toContain(bucketId);
-        expect(Object.keys(persistent)).not.toContain('bucket2');
+
+        it('should initialize with fillFromStart tokens', () => {
+            const fillBucket: Bucket = {
+                name: 'fill',
+                type: 'simple',
+                maxTokens: 20,
+                refillRate: 2, // 2 tokens/sec
+                startTokens: 0,
+                fillFromStart: true,
+                persistBucket: true,
+                lifetimeMaxTokens: false,
+                lifetimeMaxTokensValue: 0,
+                fillBucketAcrossRestarts: false
+            };
+            mockedBucketService.__setBuckets({
+                fill: fillBucket
+            });
+            // Simulate 5 seconds since start
+            const fiveSecondsAgo = now;
+            const nowPlus5s = now + 5000;
+            jest.setSystemTime(nowPlus5s);
+            const bucketData = new BucketData(fiveSecondsAgo);
+            // The first addTokens should initialize with fillTokens = refillRate * (now - startTime) / 1000
+            // But since startTokens is 0, should be 2 * 5 = 10 tokens
+            const entry = bucketData.addTokens('fill', fillBucket, key);
+            expect(entry.tokenCount).toBe(10);
+            expect(entry.lifetimeTokenCount).toBe(10);
+        });
+
+        it('should initialize and load empty data', () => {
+            const bucketData = new BucketData();
+            expect(bucketData.getAllBucketData(bucketId)).toEqual({});
+        });
+
+        it('should add tokens and update bucket data', () => {
+            const bucketData = new BucketData();
+            const entry = bucketData.addTokens(bucketId, bucket, key);
+            expect(entry.tokenCount).toBe(bucket.startTokens);
+            expect(entry.lifetimeTokenCount).toBe(bucket.startTokens);
+            expect(entry.invocationCount).toBe(0);
+            expect(typeof entry.lastUpdated).toBe('number');
+        });
     });
 
-    it('should handle missing bucket in check gracefully', () => {
-        const request: CheckRateLimitRequest = {
-            bucketId: 'notfound',
-            bucketType: 'simple',
-            key,
-            tokenRequest: 1,
-            inquiry: false,
-            bucketSize: 10,
-            bucketRate: 1,
-            invocationLimit: false,
-            invocationLimitValue: 0
-        };
-        const res = bucketData.check(request);
-        expect(res.success).toBe(true);
-        expect(res.remaining).toBe(-1);
+    describe('check', () => {
+        it('should check and allow if enough tokens', () => {
+            const request: CheckRateLimitRequest = {
+                bucketId,
+                bucketType: 'simple',
+                key,
+                tokenRequest: 2,
+                inquiry: false,
+                bucketSize: 10,
+                bucketRate: 1,
+                invocationLimit: false,
+                invocationLimitValue: 0
+            };
+            const bucketData = new BucketData();
+            const res = bucketData.check(request);
+            expect(res.success).toBe(true);
+            expect(res.remaining).toBe(-1);
+            expect(res.invocation).toBe(1);
+        });
+
+        it('should check and reject if not enough tokens', () => {
+            // Use up all tokens
+            const request: CheckRateLimitRequest = {
+                bucketId,
+                bucketType: 'simple',
+                key,
+                tokenRequest: 10,
+                inquiry: false,
+                bucketSize: 10,
+                bucketRate: 1,
+                invocationLimit: false,
+                invocationLimitValue: 0
+            };
+            const bucketData = new BucketData();
+            bucketData.check(request); // uses 5 tokens
+            bucketData.check(request); // should fail
+            const res = bucketData.check(request);
+            expect(res.success).toBe(false);
+            expect(res.rejectReason).toBe(RejectReason.RateLimit);
+            expect(typeof res.next).toBe('number');
+            expect(res.errorMessage).toMatch(/Insufficient tokens/);
+        });
+
+        it('should check and reject if invocation limit reached', () => {
+            const request: CheckRateLimitRequest = {
+                bucketId,
+                bucketType: 'simple',
+                key,
+                tokenRequest: 1,
+                inquiry: false,
+                bucketSize: 10,
+                bucketRate: 1,
+                invocationLimit: true,
+                invocationLimitValue: 1
+            };
+            const bucketData = new BucketData();
+            bucketData.check(request); // first invocation
+            const res = bucketData.check(request); // should fail
+            expect(res.success).toBe(false);
+            expect(res.rejectReason).toBe(RejectReason.InvocationLimit);
+            expect(res.remaining).toBe(0);
+            expect(res.errorMessage).toMatch(/Invocation limit reached/);
+        });
+
+        it('should handle missing bucket in check gracefully', () => {
+            const request: CheckRateLimitRequest = {
+                bucketId: 'notfound',
+                bucketType: 'simple',
+                key,
+                tokenRequest: 1,
+                inquiry: false,
+                bucketSize: 10,
+                bucketRate: 1,
+                invocationLimit: false,
+                invocationLimitValue: 0
+            };
+            const bucketData = new BucketData();
+            const res = bucketData.check(request);
+            expect(res.success).toBe(true);
+            expect(res.remaining).toBe(-1);
+        });
+    });
+
+    describe('deleteKey', () => {
+        it('should delete a key', () => {
+            const bucketData = new BucketData();
+            bucketData.addTokens(bucketId, bucket, key);
+            expect(bucketData.deleteKey(bucketId, key)).toBe(true);
+            expect(bucketData.hasKey(bucketId, key)).toBe(false);
+        });
+
+        it('should return false when deleting non-existent key', () => {
+            const bucketData = new BucketData();
+            expect(bucketData.deleteKey(bucketId, 'notfound')).toBe(false);
+        });
+    });
+
+    describe('listKeys', () => {
+        it('should list keys', () => {
+            const bucketData = new BucketData();
+            bucketData.addTokens(bucketId, bucket, key);
+            expect(bucketData.listKeys(bucketId)).toContain(key);
+        });
+    });
+
+    describe('setKey', () => {
+        it('should set key data', () => {
+            const bucketData = new BucketData();
+            bucketData.addTokens(bucketId, bucket, key);
+            const newData: BucketDataEntry = {
+                tokenCount: 2,
+                lifetimeTokenCount: 2,
+                lastUpdated: now,
+                invocationCount: 1
+            };
+            bucketData.setKey(bucketId, key, newData);
+            expect(bucketData.getAllBucketData(bucketId)[key]).toEqual(newData);
+        });
+
+        it('should not set key for non-existent bucket', () => {
+            const spy = jest.spyOn(require('../main').logger, 'error');
+            const bucketData = new BucketData();
+            bucketData.setKey('notfound', key, {
+                tokenCount: 1,
+                lifetimeTokenCount: 1,
+                lastUpdated: now,
+                invocationCount: 0
+            });
+            expect(spy).toHaveBeenCalled();
+        });
+    });
+
+    describe('getPersistentBucketData', () => {
+        it('should persist only buckets with persistBucket=true', () => {
+            const bucket2: Bucket = {
+                name: 'bucket2',
+                type: 'simple',
+                maxTokens: 10,
+                refillRate: 1,
+                startTokens: 5,
+                fillFromStart: false,
+                persistBucket: false,
+                lifetimeMaxTokens: false,
+                lifetimeMaxTokensValue: 0,
+                fillBucketAcrossRestarts: false
+            };
+            mockedBucketService.__setBuckets({
+                [bucketId]: bucket,
+                bucket2
+            });
+            const bucketData = new BucketData();
+            bucketData.addTokens(bucketId, bucket, key);
+            bucketData.addTokens('bucket2', bucket2, 'key2');
+            const persistent = (bucketData as any).getPersistentBucketData();
+            expect(Object.keys(persistent)).toContain(bucketId);
+            expect(Object.keys(persistent)).not.toContain('bucket2');
+        });
     });
 });

--- a/src/backend/bucket-service.test.ts
+++ b/src/backend/bucket-service.test.ts
@@ -40,6 +40,7 @@ describe('BucketService', () => {
         startTokens: 5,
         fillFromStart: false,
         persistBucket: true,
+        fillBucketAcrossRestarts: false,
         lifetimeMaxTokens: false,
         lifetimeMaxTokensValue: 0
     };

--- a/src/backend/bucket-service.ts
+++ b/src/backend/bucket-service.ts
@@ -115,7 +115,8 @@ export class BucketService {
                 lifetimeMaxTokens: false,
                 lifetimeMaxTokensValue: 0,
                 persistBucket: false,
-                fillFromStart: true
+                fillFromStart: false,
+                fillBucketAcrossRestarts: false
             };
             return this.buckets[bucketId];
         }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -8,6 +8,7 @@ export type Bucket = {
     lifetimeMaxTokensValue: number;
     persistBucket: boolean;
     fillFromStart: boolean;
+    fillBucketAcrossRestarts: boolean;
 }
 
 export type BucketWithId = Bucket & {

--- a/src/ui-extensions/rate-limiter.ts
+++ b/src/ui-extensions/rate-limiter.ts
@@ -41,6 +41,7 @@ const rateLimiterAddOrEditBucket: AngularJsComponent = {
         bucketLifetimeMaxTokens: "=",
         bucketLifetimeMaxTokensValue: "=",
         persistBucket: "=",
+        fillBucketAcrossRestarts: "=",
         saveButton: "&",
         cancelButton: "&"
     },
@@ -70,10 +71,13 @@ const rateLimiterAddOrEditBucket: AngularJsComponent = {
                     <firebot-input input-title="Lifetime Max Tokens" model="$ctrl.bucketLifetimeMaxTokensValue" data-type="number" required disable-variables="true" />
                 </div>
                 <div class="form-group">
-                    <firebot-checkbox label="Fill from start" model="$ctrl.bucketFillFromStart" tooltip="If checked, token replenishment will occur from the start of the stream (when Firebot is opened). This is different from the default behavior, where token replenishment begins after the first request." />
+                    <firebot-checkbox label="Fill from Firebot startup" model="$ctrl.bucketFillFromStart" tooltip="If checked, token replenishment will occur from the start of the stream (when Firebot is opened). This is different from the default behavior, where token replenishment begins after the first request." />
                 </div>
                 <div class="form-group">
                     <firebot-checkbox label="Persist bucket data across Firebot restarts" model="$ctrl.persistBucket" tooltip="If checked, the bucket data will be saved to a file and restored across Firebot restarts." />
+                </div>
+                <div class="form-group" ng-if="$ctrl.persistBucket">
+                    <firebot-checkbox label="Fill across Firebot restarts" model="$ctrl.fillBucketAcrossRestarts" tooltip="If checked, token replenishment will be simulated across streams and Firebot restarts, as if Firebot had not ever been shut down." />
                 </div>
                 <div style="display: flex; gap: 10px; justify-content: center; width: 100%; margin-top: 20px;">
                     <button class="btn btn-default" ng-click="$ctrl.cancelButton()">Cancel</button>
@@ -175,7 +179,8 @@ const rateLimiterPage: AngularJsPage = {
                     bucket-lifetime-max-tokens="bucketLifetimeMaxTokens"
                     bucket-lifetime-max-tokens-value="bucketLifetimeMaxTokensValue"
                     persist-bucket="persistBucket"
-                    save-button="saveButton(bucketId, bucketName, bucketStartTokens, bucketMaxTokens, bucketRefillRate, bucketFillFromStart, bucketLifetimeMaxTokens, bucketLifetimeMaxTokensValue, persistBucket)"
+                    fill-bucket-across-restarts="fillBucketAcrossRestarts"
+                    save-button="saveButton(bucketId, bucketName, bucketStartTokens, bucketMaxTokens, bucketRefillRate, bucketFillFromStart, bucketLifetimeMaxTokens, bucketLifetimeMaxTokensValue, persistBucket, fillBucketAcrossRestarts)"
                     cancel-button="cancelButton()" />
             </div>
         </div>
@@ -199,6 +204,7 @@ const rateLimiterPage: AngularJsPage = {
             $scope.bucketLifetimeMaxTokens = bucket.lifetimeMaxTokens === true;
             $scope.bucketLifetimeMaxTokensValue = bucket.lifetimeMaxTokensValue === undefined ? 999999999 : bucket.lifetimeMaxTokensValue;
             $scope.persistBucket = bucket.persistBucket !== undefined ? bucket.persistBucket : false;
+            $scope.fillBucketAcrossRestarts = bucket.fillBucketAcrossRestarts === true;
             $scope.displayAddOrEditBucket = true;
         };
 
@@ -233,7 +239,7 @@ const rateLimiterPage: AngularJsPage = {
             $scope.displayDeleteConfirmation = true;
         };
 
-        $scope.saveButton = (bucketIdIn: string, bucketName: string, bucketStartTokens: number, bucketMaxTokens: number, bucketRefillRate: number, bucketFillFromStart: boolean, bucketLifetimeMaxTokens: boolean, bucketLifetimeMaxTokensValue: number, persistBucket: boolean) => {
+        $scope.saveButton = (bucketIdIn: string, bucketName: string, bucketStartTokens: number, bucketMaxTokens: number, bucketRefillRate: number, bucketFillFromStart: boolean, bucketLifetimeMaxTokens: boolean, bucketLifetimeMaxTokensValue: number, persistBucket: boolean, fillBucketAcrossRestarts: boolean) => {
             const bucketId = bucketIdIn || crypto.randomUUID();
             const data: Bucket = {
                 name: bucketName.trim(),
@@ -244,7 +250,8 @@ const rateLimiterPage: AngularJsPage = {
                 fillFromStart: bucketFillFromStart,
                 lifetimeMaxTokens: bucketLifetimeMaxTokens,
                 lifetimeMaxTokensValue: bucketLifetimeMaxTokensValue,
-                persistBucket: persistBucket
+                persistBucket: persistBucket,
+                fillBucketAcrossRestarts: fillBucketAcrossRestarts
             };
 
             const response = rateLimiterService.saveBucket(bucketId, data);


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
This adds an option for an advanced bucket to fill across restarts. The option must be set to persist the bucket to disk. When that happens, if a check of the bucket happens at T1 during one Firebot session, and then a check of the bucket happens at T2 during another Firebot session, the bucket will be refilled at (T2-T1)*refillRate.

### Motivation
This enables long-running limits. For example, to limit a user to one invocation per 30 days, you could create an advanced bucket with start and max tokens 2592000 (60*60*24*30) and refill rate of 1 token/sec. Check both "Persist bucket data across Firebot restarts" and "Fill across Firebot restarts." Then create an Rate Limiter: Check Request effect that requires 2592000 tokens.

### Testing
Unit tests were updated to cover this and I confirmed that cross-restart rate limits work in my implementation.
