### PR TITLE
Event for rate limit approved

### DIFF
--- a/src/backend/bucket-service.ts
+++ b/src/backend/bucket-service.ts
@@ -62,6 +62,7 @@ export class BucketService {
         logger.debug("Registered rate-limiter:getBuckets frontend communicator handler.");
 
         this.frontendCommunicator.on("rate-limiter:getBucketsAsArray", (): GetBucketsAsArrayResponse => {
+            logger.debug("rate-limiter:getBucketsAsArray request received.");
             if (this.fileReadError) {
                 return { buckets: [], errorMessage: this.fileReadError };
             }

--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -17,6 +17,14 @@ const eventSource: EventSource = {
                 errorMessage: "Rate limit exceeded. Please try again later.",
                 rejectReason: RejectReason.RateLimit
             }
+        },
+        {
+            id: "approved",
+            name: "Rate Limit Approved",
+            description: "Fires when a rate limit check passes.",
+            manualMetadata: {
+                bucketId: ""
+            }
         }
     ]
 };

--- a/src/filters/bucket.test.ts
+++ b/src/filters/bucket.test.ts
@@ -1,0 +1,73 @@
+// Mocks must be defined before imports due to Jest hoisting
+let mockLogger: any;
+let mockBucketService: any;
+jest.mock('../backend/bucket-service', () => {
+    mockBucketService = {
+        getAdvancedBucketsEnabled: jest.fn(),
+        getBucket: jest.fn()
+    };
+    // Attach to global for test access
+    (global as any).mockBucketService = mockBucketService;
+    return { bucketService: mockBucketService };
+});
+jest.mock('../main', () => {
+    mockLogger = { debug: jest.fn(), warn: jest.fn() };
+    (global as any).mockLogger = mockLogger;
+    return { logger: mockLogger };
+});
+
+import { bucketFilter } from './bucket';
+
+// Use global mocks in tests
+const logger = (global as any).mockLogger;
+const bucketService = (global as any).mockBucketService;
+
+describe('bucketFilter.predicate', () => {
+    const filterSettings = { value: 'bucket1', comparisonType: 'is' };
+    const eventData = { eventSourceId: 'rate-limiter', eventId: 'approved', eventMeta: { bucketId: 'bucket1' } };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('returns true if bucketId or filter value is missing', async () => {
+        const noBucketId = { eventSourceId: 'rate-limiter', eventId: 'approved', eventMeta: {} };
+        const noValue = { value: undefined, comparisonType: 'is' };
+        expect(await bucketFilter.predicate(filterSettings, noBucketId)).toBe(true);
+        expect(await bucketFilter.predicate(noValue, eventData)).toBe(true);
+        expect(logger.warn).toHaveBeenCalled();
+    });
+
+    it('returns true if advanced buckets are disabled', async () => {
+        bucketService.getAdvancedBucketsEnabled.mockReturnValue(false);
+        expect(await bucketFilter.predicate(filterSettings, eventData)).toBe(true);
+        expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Advanced buckets are disabled'));
+    });
+
+    it('returns true if bucket is not found', async () => {
+        bucketService.getAdvancedBucketsEnabled.mockReturnValue(true);
+        bucketService.getBucket.mockReturnValue(undefined);
+        expect(await bucketFilter.predicate(filterSettings, eventData)).toBe(true);
+        expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Bucket in filter is no longer valid'));
+    });
+
+    it('returns correct logic for comparisonType "is"', async () => {
+        bucketService.getAdvancedBucketsEnabled.mockReturnValue(true);
+        bucketService.getBucket.mockReturnValue({});
+        // bucketId === value, comparisonType === 'is' => true
+        expect(await bucketFilter.predicate(filterSettings, eventData)).toBe(true);
+        // bucketId !== value, comparisonType === 'is' => false
+        const otherEventData = { eventSourceId: 'rate-limiter', eventId: 'approved', eventMeta: { bucketId: 'other' } };
+        expect(await bucketFilter.predicate(filterSettings, otherEventData)).toBe(false);
+    });
+
+    it('returns correct logic for comparisonType "is not"', async () => {
+        bucketService.getAdvancedBucketsEnabled.mockReturnValue(true);
+        bucketService.getBucket.mockReturnValue({});
+        // bucketId === value, comparisonType === 'is not' => false
+        expect(await bucketFilter.predicate({ value: 'bucket1', comparisonType: 'is not' }, eventData)).toBe(false);
+        // bucketId !== value, comparisonType === 'is not' => true
+        const otherEventData = { eventSourceId: 'rate-limiter', eventId: 'approved', eventMeta: { bucketId: 'other' } };
+        expect(await bucketFilter.predicate({ value: 'bucket1', comparisonType: 'is not' }, otherEventData)).toBe(true);
+    });
+});

--- a/src/filters/bucket.ts
+++ b/src/filters/bucket.ts
@@ -1,0 +1,90 @@
+import { EventData, EventFilter, FilterSettings, PresetValue } from "@crowbartools/firebot-custom-scripts-types/types/modules/event-filter-manager";
+import { bucketService } from "../backend/bucket-service";
+import { logger } from "../main";
+import { GetBucketResponse, GetBucketsAsArrayResponse } from "../shared/types";
+
+export const bucketFilter: EventFilter = {
+    id: `rate-limiter:bucket`,
+    name: "Rate Limiter Bucket",
+    description: "Limit to a specific bucket that triggered the event",
+    events: [
+        { eventSourceId: "rate-limiter", eventId: "limit-exceeded" },
+        { eventSourceId: "rate-limiter", eventId: "approved" }
+    ],
+    comparisonTypes: ["is", "is not"],
+    valueType: "preset",
+    getSelectedValueDisplay: (filterSettings: FilterSettings, backendCommunicator: any): string => {
+        const bucketResponse: GetBucketResponse = backendCommunicator.fireEventSync("rate-limiter:getBucket", { bucketId: filterSettings.value });
+        if (bucketResponse.errorMessage) {
+            return "[Error]";
+        }
+
+        return bucketResponse.bucket ? bucketResponse.bucket.name : "[Unknown]";
+    },
+    valueIsStillValid: (filterSettings: FilterSettings, backendCommunicator: any): boolean => {
+        const advancedBucketsEnabled = backendCommunicator.fireEventSync("rate-limiter:getAdvancedBucketsEnabled", {});
+        if (!advancedBucketsEnabled) {
+            return false;
+        }
+
+        const bucketResponse: GetBucketResponse = backendCommunicator.fireEventSync("rate-limiter:getBucket", { bucketId: filterSettings.value });
+        if (bucketResponse.errorMessage) {
+            return false;
+        }
+
+        return !!bucketResponse.bucket;
+    },
+    presetValues: (backendCommunicator: any, ngToast: any): PresetValue[] => {
+        const advancedBucketsEnabled = backendCommunicator.fireEventSync("rate-limiter:getAdvancedBucketsEnabled", {});
+        if (!advancedBucketsEnabled) {
+            ngToast.create({className: 'danger', content: "This filter is not available because you have not enabled advanced buckets."});
+            return [];
+        }
+
+        const bucketsResponse: GetBucketsAsArrayResponse = backendCommunicator.fireEventSync("rate-limiter:getBucketsAsArray", {});
+        if (bucketsResponse.errorMessage) {
+            ngToast.create({className: 'danger', content: `Error loading buckets: ${bucketsResponse.errorMessage}`});
+            return [];
+        }
+
+        if (bucketsResponse.buckets.length === 0) {
+            ngToast.create({className: 'danger', content: "No buckets found. Create some in the 'RATE LIMITER' screen."});
+            return [];
+        }
+
+        return bucketsResponse.buckets.map(bucket => ({
+            value: bucket.id,
+            display: bucket.name
+        }));
+    },
+    predicate: async (
+        filterSettings,
+        eventData: EventData
+    ): Promise<boolean> => {
+        // If the bucket data is unknown then always return true.
+        const bucketId = typeof eventData.eventMeta?.bucketId === "string" ? eventData.eventMeta.bucketId : undefined;
+        if (!bucketId || !filterSettings.value) {
+            logger.warn("bucketFilter: Bucket ID or filter value is missing. Passing event.");
+            return true;
+        }
+
+        // If advanced buckets are disabled then always return true.
+        const advancedBucketsEnabled = bucketService.getAdvancedBucketsEnabled();
+        if (!advancedBucketsEnabled) {
+            logger.warn("bucketFilter: Advanced buckets are disabled. Passing event.");
+            return true;
+        }
+
+        // If the bucket is no longer valid then always return true.
+        const bucket = bucketService.getBucket(bucketId);
+        if (!bucket) {
+            logger.warn("bucketFilter: Bucket in filter is no longer valid. Passing event.");
+            return true;
+        }
+
+        // True if bucketId matches value and comparisonType is "is", or if they don't match and comparisonType is "is not"
+        const result = ((bucketId === String(filterSettings.value)) === (filterSettings.comparisonType === "is"));
+        logger.debug(`bucketFilter: result=${result} bucketId=${bucketId} filterValue=${filterSettings.value} comparisonType=${filterSettings.comparisonType}`);
+        return result;
+    }
+};

--- a/src/filters/index.ts
+++ b/src/filters/index.ts
@@ -1,0 +1,7 @@
+import { firebot } from "../main";
+import { bucketFilter } from "./bucket";
+
+export function registerFilters(): void {
+    const { eventFilterManager } = firebot.modules;
+    eventFilterManager.registerFilter(bucketFilter);
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import { initializeBucketData } from './backend/bucket-data';
 import { bucketService, initializeBucketService } from './backend/bucket-service';
 import { registerEffects } from './effects';
 import { registerEventSource } from './events';
+import { registerFilters } from './filters';
 import { ScriptSettings } from './shared/types';
 import { registerUIExtensions } from './ui-extensions';
 import { registerReplaceVariables } from './variables';
@@ -64,6 +65,7 @@ const script: Firebot.CustomScript<ScriptSettings> = {
         initializeBucketData();
         registerEffects();
         registerEventSource();
+        registerFilters();
         registerReplaceVariables();
 
         const settings = runRequest.parameters;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -68,6 +68,18 @@ export type GetBucketsAsArrayResponse = {
     errorMessage?: string; // Optional error message
 }
 
+export type LimitApprovedEventMetadata = {
+    alwaysAllow: boolean; // Whether this approval was based on an "always" condition
+    success: boolean; // Whether the success was actually true, not considering "always" condition
+    bucketId: string;
+    bucketKey: string;
+    username: string;
+    messageId: string; // ID of the chat message that triggered the check
+    triggerMetadata: Record<string, any>; // Original event data that triggered the check
+    triggerType: string; // Type of the original event source
+    triggerUsername: string; // Username from the original event source if tracked
+}
+
 export type LimitExceededEventMetadata = {
     bucketId: string;
     bucketKey: string;


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
This adds a "Rate Limit Approved" event that can be triggered when the rate limit on an advanced bucket is approved.

### Motivation
This allows a single rate limit to be more conveniently shared across two or more trigger events. While this was technically achievable before through conditional effects, the new implementation is much easier and allows effect setup to be more DRY (don't repeat yourself).

### Testing
Updated README with my setup (which works) and also added some tests.
