### PR TITLE
Effects to run upon failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ node_modules/
 /.claude
 /.github/copilot-instructions.md
 /AGENTS.md
+/opencode.json
+/plans/
+.grepai/

--- a/src/effects/check.test.ts
+++ b/src/effects/check.test.ts
@@ -40,6 +40,9 @@ jest.mock('../main', () => ({
             frontendCommunicator: {
                 on: jest.fn(),
                 send: jest.fn()
+            },
+            effectRunner: {
+                processEffects: jest.fn()
             }
         }
     }
@@ -60,6 +63,7 @@ describe('checkEffect.onTriggerEvent', () => {
     let bucketService: BucketService;
     let mockTwitchApi: jest.MockedFunction<any>;
     let mockEmitEvent: jest.MockedFunction<any>;
+    let mockEffectRunner: jest.MockedFunction<any>;
 
     beforeEach(() => {
         jest.clearAllMocks();
@@ -68,6 +72,7 @@ describe('checkEffect.onTriggerEvent', () => {
         const { firebot } = require('../main');
         mockTwitchApi = firebot.modules.twitchApi.channelRewards.approveOrRejectChannelRewardRedemption;
         mockEmitEvent = require('../events').emitEvent;
+        mockEffectRunner = firebot.modules.effectRunner.processEffects;
 
         // Create actual bucket service and data instances for testing
         bucketService = new BucketService();
@@ -964,6 +969,569 @@ describe('checkEffect.onTriggerEvent', () => {
                 const outputs = result.outputs as any;
                 expect(outputs.rateLimitAllowed).toBe('false');
                 expect(outputs.rateLimitApprovalId).toBe('');
+            }
+        });
+    });
+
+    describe('Failure effect list', () => {
+        it('should not execute failure effects when runOnFailure is disabled', async () => {
+            const effect = {
+                id: 'test-effect',
+                bucketId: 'test-bucket-id',
+                bucketType: 'simple' as const,
+                bucketSize: 1,
+                bucketRate: 0.1,
+                keyType: 'user' as const,
+                key: '',
+                tokens: 10,
+                inquiry: false,
+                enforceStreamer: true,
+                enforceBot: true,
+                rejectReward: false,
+                stopExecution: false,
+                stopExecutionBubble: false,
+                triggerEvent: false,
+                triggerApproveEvent: false,
+                rateLimitMetadata: '',
+                invocationLimit: false,
+                invocationLimitValue: 0,
+                runOnFailure: false,
+                failureEffectList: { list: [{ id: 'some-effect' }] }
+            };
+
+            const trigger = {
+                type: 'command' as const,
+                metadata: {
+                    username: 'testuser'
+                }
+            };
+
+            const result = await checkEffect.onTriggerEvent({
+                effect,
+                trigger,
+                // eslint-disable-next-line @typescript-eslint/no-empty-function
+                sendDataToOverlay: () => {},
+                abortSignal: new AbortController().signal
+            });
+
+            expect(result).toBeTruthy();
+            if (result && typeof result === 'object' && 'outputs' in result) {
+                expect(result.outputs?.rateLimitAllowed).toBe('false');
+            }
+            expect(mockEffectRunner).not.toHaveBeenCalled();
+        });
+
+        it('should execute failure effects when runOnFailure is enabled and limit exceeded', async () => {
+            const failureEffects = { list: [{ id: 'test-effect', type: 'some-type' }] };
+            const effect = {
+                id: 'test-effect',
+                bucketId: 'test-bucket-id',
+                bucketType: 'simple' as const,
+                bucketSize: 1,
+                bucketRate: 0.1,
+                keyType: 'user' as const,
+                key: '',
+                tokens: 10,
+                inquiry: false,
+                enforceStreamer: true,
+                enforceBot: true,
+                rejectReward: false,
+                stopExecution: false,
+                stopExecutionBubble: false,
+                triggerEvent: false,
+                triggerApproveEvent: false,
+                rateLimitMetadata: '',
+                invocationLimit: false,
+                invocationLimitValue: 0,
+                runOnFailure: true,
+                failureEffectList: failureEffects
+            };
+
+            const trigger = {
+                type: 'command' as const,
+                metadata: {
+                    username: 'testuser'
+                }
+            };
+
+            const result = await checkEffect.onTriggerEvent({
+                effect,
+                trigger,
+                // eslint-disable-next-line @typescript-eslint/no-empty-function
+                sendDataToOverlay: () => {},
+                abortSignal: new AbortController().signal
+            });
+
+            expect(result).toBeTruthy();
+            if (result && typeof result === 'object' && 'outputs' in result) {
+                expect(result.outputs?.rateLimitAllowed).toBe('false');
+            }
+            expect(mockEffectRunner).toHaveBeenCalledWith({
+                trigger: trigger,
+                effects: failureEffects,
+                outputs: expect.any(Object)
+            });
+        });
+
+        it('should execute failure effects before stop execution is returned', async () => {
+            const failureEffects = { list: [{ id: 'test-effect' }] };
+            const effect = {
+                id: 'test-effect',
+                bucketId: 'test-bucket-id',
+                bucketType: 'simple' as const,
+                bucketSize: 1,
+                bucketRate: 0.1,
+                keyType: 'user' as const,
+                key: '',
+                tokens: 10,
+                inquiry: false,
+                enforceStreamer: true,
+                enforceBot: true,
+                rejectReward: false,
+                stopExecution: true,
+                stopExecutionBubble: false,
+                triggerEvent: false,
+                triggerApproveEvent: false,
+                rateLimitMetadata: '',
+                invocationLimit: false,
+                invocationLimitValue: 0,
+                runOnFailure: true,
+                failureEffectList: failureEffects
+            };
+
+            const trigger = {
+                type: 'command' as const,
+                metadata: {
+                    username: 'testuser'
+                }
+            };
+
+            const result = await checkEffect.onTriggerEvent({
+                effect,
+                trigger,
+                // eslint-disable-next-line @typescript-eslint/no-empty-function
+                sendDataToOverlay: () => {},
+                abortSignal: new AbortController().signal
+            });
+
+            expect(mockEffectRunner).toHaveBeenCalled();
+            expect(result).toBeTruthy();
+            if (result && typeof result === 'object' && 'execution' in result) {
+                expect(result.execution?.stop).toBe(true);
+            }
+        });
+
+        it('should not execute failure effects when request is allowed', async () => {
+            const failureEffects = { list: [{ id: 'test-effect' }] };
+            const effect = {
+                id: 'test-effect',
+                bucketId: 'test-bucket-id',
+                bucketType: 'simple' as const,
+                bucketSize: 100,
+                bucketRate: 10,
+                keyType: 'user' as const,
+                key: '',
+                tokens: 1,
+                inquiry: false,
+                enforceStreamer: true,
+                enforceBot: true,
+                rejectReward: false,
+                stopExecution: false,
+                stopExecutionBubble: false,
+                triggerEvent: false,
+                triggerApproveEvent: false,
+                rateLimitMetadata: '',
+                invocationLimit: false,
+                invocationLimitValue: 0,
+                runOnFailure: true,
+                failureEffectList: failureEffects
+            };
+
+            const trigger = {
+                type: 'command' as const,
+                metadata: {
+                    username: 'testuser'
+                }
+            };
+
+            const result = await checkEffect.onTriggerEvent({
+                effect,
+                trigger,
+                // eslint-disable-next-line @typescript-eslint/no-empty-function
+                sendDataToOverlay: () => {},
+                abortSignal: new AbortController().signal
+            });
+
+            expect(result).toBeTruthy();
+            if (result && typeof result === 'object' && 'outputs' in result) {
+                expect(result.outputs?.rateLimitAllowed).toBe('true');
+            }
+            expect(mockEffectRunner).not.toHaveBeenCalled();
+        });
+
+        it('should handle errors in failure effect execution gracefully', async () => {
+            const { logger } = require('../main');
+            mockEffectRunner.mockRejectedValue(new Error('Effect failed'));
+
+            const failureEffects = { list: [{ id: 'test-effect' }] };
+            const effect = {
+                id: 'test-effect',
+                bucketId: 'test-bucket-id',
+                bucketType: 'simple' as const,
+                bucketSize: 1,
+                bucketRate: 0.1,
+                keyType: 'user' as const,
+                key: '',
+                tokens: 10,
+                inquiry: false,
+                enforceStreamer: true,
+                enforceBot: true,
+                rejectReward: false,
+                stopExecution: false,
+                stopExecutionBubble: false,
+                triggerEvent: false,
+                triggerApproveEvent: false,
+                rateLimitMetadata: '',
+                invocationLimit: false,
+                invocationLimitValue: 0,
+                runOnFailure: true,
+                failureEffectList: failureEffects
+            };
+
+            const trigger = {
+                type: 'command' as const,
+                metadata: {
+                    username: 'testuser'
+                }
+            };
+
+            const result = await checkEffect.onTriggerEvent({
+                effect,
+                trigger,
+                // eslint-disable-next-line @typescript-eslint/no-empty-function
+                sendDataToOverlay: () => {},
+                abortSignal: new AbortController().signal
+            });
+
+            expect(result).toBeTruthy();
+            if (result && typeof result === 'object' && 'outputs' in result) {
+                expect(result.outputs?.rateLimitAllowed).toBe('false');
+            }
+            expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('Failed to execute failure effect list'));
+        });
+
+        it('should clone outputs when executing failure effects', async () => {
+            const failureEffects = { list: [{ id: 'test-effect' }] };
+            const effect = {
+                id: 'test-effect',
+                bucketId: 'test-bucket-id',
+                bucketType: 'simple' as const,
+                bucketSize: 1,
+                bucketRate: 0.1,
+                keyType: 'user' as const,
+                key: '',
+                tokens: 10,
+                inquiry: false,
+                enforceStreamer: true,
+                enforceBot: true,
+                rejectReward: false,
+                stopExecution: false,
+                stopExecutionBubble: false,
+                triggerEvent: false,
+                triggerApproveEvent: false,
+                rateLimitMetadata: '',
+                invocationLimit: false,
+                invocationLimitValue: 0,
+                runOnFailure: true,
+                failureEffectList: failureEffects
+            };
+
+            const trigger = {
+                type: 'command' as const,
+                metadata: {
+                    username: 'testuser'
+                }
+            };
+
+            const testEvent = {
+                effect,
+                trigger,
+                // eslint-disable-next-line @typescript-eslint/no-empty-function
+                sendDataToOverlay: () => {},
+                abortSignal: new AbortController().signal,
+                outputs: {
+                    testOutput: 'value'
+                }
+            };
+
+            await checkEffect.onTriggerEvent(testEvent);
+
+            expect(mockEffectRunner).toHaveBeenCalled();
+            const callArg = mockEffectRunner.mock.calls[0][0];
+            expect(callArg.outputs).not.toBe(testEvent.outputs);
+            expect(callArg.outputs).toEqual(testEvent.outputs);
+        });
+
+        it('should set stop to true when failure effects request it', async () => {
+            mockEffectRunner.mockResolvedValue({
+                success: true,
+                stopEffectExecution: true,
+                outputs: {}
+            });
+
+            const failureEffects = { list: [{ id: 'test-effect' }] };
+            const effect = {
+                id: 'test-effect',
+                bucketId: 'test-bucket-id',
+                bucketType: 'simple' as const,
+                bucketSize: 1,
+                bucketRate: 0.1,
+                keyType: 'user' as const,
+                key: '',
+                tokens: 10,
+                inquiry: false,
+                enforceStreamer: true,
+                enforceBot: true,
+                rejectReward: false,
+                stopExecution: false,
+                stopExecutionBubble: false,
+                triggerEvent: false,
+                triggerApproveEvent: false,
+                rateLimitMetadata: '',
+                invocationLimit: false,
+                invocationLimitValue: 0,
+                runOnFailure: true,
+                failureEffectList: failureEffects
+            };
+
+            const trigger = {
+                type: 'command' as const,
+                metadata: {
+                    username: 'testuser'
+                }
+            };
+
+            const result = await checkEffect.onTriggerEvent({
+                effect,
+                trigger,
+                // eslint-disable-next-line @typescript-eslint/no-empty-function
+                sendDataToOverlay: () => {},
+                abortSignal: new AbortController().signal
+            });
+
+            expect(result).toBeTruthy();
+            if (result && typeof result === 'object' && 'execution' in result) {
+                expect(result.execution?.stop).toBe(true);
+            }
+        });
+
+        it('should keep stop and bubbleStop false when failure effects do not request them', async () => {
+            mockEffectRunner.mockResolvedValue({
+                success: true,
+                stopEffectExecution: false,
+                outputs: {}
+            });
+
+            const failureEffects = { list: [{ id: 'test-effect' }] };
+            const effect = {
+                id: 'test-effect',
+                bucketId: 'test-bucket-id',
+                bucketType: 'simple' as const,
+                bucketSize: 1,
+                bucketRate: 0.1,
+                keyType: 'user' as const,
+                key: '',
+                tokens: 10,
+                inquiry: false,
+                enforceStreamer: true,
+                enforceBot: true,
+                rejectReward: false,
+                stopExecution: false,
+                stopExecutionBubble: false,
+                triggerEvent: false,
+                triggerApproveEvent: false,
+                rateLimitMetadata: '',
+                invocationLimit: false,
+                invocationLimitValue: 0,
+                runOnFailure: true,
+                failureEffectList: failureEffects
+            };
+
+            const trigger = {
+                type: 'command' as const,
+                metadata: {
+                    username: 'testuser'
+                }
+            };
+
+            const result = await checkEffect.onTriggerEvent({
+                effect,
+                trigger,
+                // eslint-disable-next-line @typescript-eslint/no-empty-function
+                sendDataToOverlay: () => {},
+                abortSignal: new AbortController().signal
+            });
+
+            expect(result).toBeTruthy();
+            if (result && typeof result === 'object' && 'execution' in result) {
+                expect(result.execution?.stop).toBe(false);
+            }
+        });
+
+        it('should keep stop and bubbleStop true when rate limiter options are true', async () => {
+            mockEffectRunner.mockResolvedValue({
+                success: true,
+                stopEffectExecution: false,
+                outputs: {}
+            });
+
+            const failureEffects = { list: [{ id: 'test-effect' }] };
+            const effect = {
+                id: 'test-effect',
+                bucketId: 'test-bucket-id',
+                bucketType: 'simple' as const,
+                bucketSize: 1,
+                bucketRate: 0.1,
+                keyType: 'user' as const,
+                key: '',
+                tokens: 10,
+                inquiry: false,
+                enforceStreamer: true,
+                enforceBot: true,
+                rejectReward: false,
+                stopExecution: true,
+                stopExecutionBubble: true,
+                triggerEvent: false,
+                triggerApproveEvent: false,
+                rateLimitMetadata: '',
+                invocationLimit: false,
+                invocationLimitValue: 0,
+                runOnFailure: true,
+                failureEffectList: failureEffects
+            };
+
+            const trigger = {
+                type: 'command' as const,
+                metadata: {
+                    username: 'testuser'
+                }
+            };
+
+            const result = await checkEffect.onTriggerEvent({
+                effect,
+                trigger,
+                // eslint-disable-next-line @typescript-eslint/no-empty-function
+                sendDataToOverlay: () => {},
+                abortSignal: new AbortController().signal
+            });
+
+            expect(result).toBeTruthy();
+            if (result && typeof result === 'object' && 'execution' in result) {
+                expect(result.execution?.stop).toBe(true);
+                expect(result.execution?.bubbleStop).toBe(true);
+            }
+        });
+
+        it('should not propagate execution stop when stopEffectExecution is false', async () => {
+            mockEffectRunner.mockResolvedValue({
+                success: true,
+                stopEffectExecution: false,
+                outputs: {}
+            });
+
+            const failureEffects = { list: [{ id: 'test-effect' }] };
+            const effect = {
+                id: 'test-effect',
+                bucketId: 'test-bucket-id',
+                bucketType: 'simple' as const,
+                bucketSize: 1,
+                bucketRate: 0.1,
+                keyType: 'user' as const,
+                key: '',
+                tokens: 10,
+                inquiry: false,
+                enforceStreamer: true,
+                enforceBot: true,
+                rejectReward: false,
+                stopExecution: false,
+                stopExecutionBubble: false,
+                triggerEvent: false,
+                triggerApproveEvent: false,
+                rateLimitMetadata: '',
+                invocationLimit: false,
+                invocationLimitValue: 0,
+                runOnFailure: true,
+                failureEffectList: failureEffects
+            };
+
+            const trigger = {
+                type: 'command' as const,
+                metadata: {
+                    username: 'testuser'
+                }
+            };
+
+            const result = await checkEffect.onTriggerEvent({
+                effect,
+                trigger,
+                // eslint-disable-next-line @typescript-eslint/no-empty-function
+                sendDataToOverlay: () => {},
+                abortSignal: new AbortController().signal
+            });
+
+            expect(result).toBeTruthy();
+            if (result && typeof result === 'object' && 'execution' in result) {
+                expect(result.execution?.stop).toBe(false);
+            }
+        });
+
+        it('should keep original values when failure effects return null (queued)', async () => {
+            mockEffectRunner.mockResolvedValue(null);
+
+            const failureEffects = { list: [{ id: 'test-effect' }] };
+            const effect = {
+                id: 'test-effect',
+                bucketId: 'test-bucket-id',
+                bucketType: 'simple' as const,
+                bucketSize: 1,
+                bucketRate: 0.1,
+                keyType: 'user' as const,
+                key: '',
+                tokens: 10,
+                inquiry: false,
+                enforceStreamer: true,
+                enforceBot: true,
+                rejectReward: false,
+                stopExecution: false,
+                stopExecutionBubble: false,
+                triggerEvent: false,
+                triggerApproveEvent: false,
+                rateLimitMetadata: '',
+                invocationLimit: false,
+                invocationLimitValue: 0,
+                runOnFailure: true,
+                failureEffectList: failureEffects
+            };
+
+            const trigger = {
+                type: 'command' as const,
+                metadata: {
+                    username: 'testuser'
+                }
+            };
+
+            const result = await checkEffect.onTriggerEvent({
+                effect,
+                trigger,
+                // eslint-disable-next-line @typescript-eslint/no-empty-function
+                sendDataToOverlay: () => {},
+                abortSignal: new AbortController().signal
+            });
+
+            expect(result).toBeTruthy();
+            if (result && typeof result === 'object' && 'execution' in result) {
+                expect(result.execution?.stop).toBe(false);
+                expect(result.execution?.bubbleStop).toBe(false);
             }
         });
     });

--- a/src/effects/check.ts
+++ b/src/effects/check.ts
@@ -27,6 +27,10 @@ type effectModel = {
     rateLimitMetadata: string;
     invocationLimit: boolean;
     invocationLimitValue: number | string;
+    runOnFailure?: boolean;
+    failureEffectList?: {
+        list: any[];
+    };
 }
 
 export const checkEffect: Firebot.EffectType<effectModel> = {
@@ -153,7 +157,15 @@ export const checkEffect: Firebot.EffectType<effectModel> = {
                 <firebot-checkbox model="effect.enforceStreamer" label="Enforce limit for streamer" />
                 <firebot-checkbox model="effect.enforceBot" label="Enforce limit for bot" />
                 <firebot-checkbox model="effect.rejectReward" label="Reject channel point reward if limit exceeded" />
-                <firebot-checkbox model="effect.stopExecution" label="Stop effect execution if limit exceeded" />
+                <firebot-checkbox model="effect.runOnFailure" label="Run effect list when rate limit is denied" />
+                <div style="margin-left: 10px" ng-if="effect.runOnFailure">
+                    <eos-container header="Effects to Run on Failure">
+                        <effect-list effects="effect.failureEffectList" update="failureEffectListUpdated(effects)"></effect-list>
+                    </eos-container>
+                </div>
+                <div style="margin-top: 8px">
+                    <firebot-checkbox model="effect.stopExecution" label="Stop effect execution if limit exceeded" />
+                </div>
                 <div style="margin-left: 10px" ng-if="effect.stopExecution">
                     <firebot-checkbox model="effect.stopExecutionBubble" label="Bubble the stop effect execution request to all parent effect lists" />
                 </div>
@@ -228,6 +240,12 @@ export const checkEffect: Firebot.EffectType<effectModel> = {
         if (effect.invocationLimit && (effect.invocationLimitValue === undefined || effect.invocationLimitValue === null || String(effect.invocationLimitValue).trim() === "")) {
             errors.push("Invocation Limit Value is required");
         }
+        if (effect.runOnFailure) {
+            const failureEffectCount = effect.failureEffectList?.list?.length ?? 0;
+            if (failureEffectCount === 0) {
+                errors.push("Please add at least one effect to the failure effect list.");
+            }
+        }
         return errors;
     },
     optionsController: ($scope: EffectScope<effectModel>, backendCommunicator: any, ngToast: any) => {
@@ -250,6 +268,12 @@ export const checkEffect: Firebot.EffectType<effectModel> = {
         $scope.effect.bucketSize = $scope.effect.bucketSize !== undefined ? $scope.effect.bucketSize : 10;
         $scope.effect.bucketRate = $scope.effect.bucketRate !== undefined ? $scope.effect.bucketRate : 1;
         $scope.effect.bucketName = $scope.effect.bucketName || "";
+        $scope.effect.runOnFailure = $scope.effect.runOnFailure === true;
+        $scope.effect.failureEffectList = $scope.effect.failureEffectList || { list: [] };
+
+        $scope.failureEffectListUpdated = function(effects: any) {
+            $scope.effect.failureEffectList = effects;
+        };
 
         $scope.bucketType = $scope.effect.bucketType;
 
@@ -433,6 +457,41 @@ export const checkEffect: Firebot.EffectType<effectModel> = {
         // We may stop execution
         result.execution.stop = effect.stopExecution;
         result.execution.bubbleStop = effect.stopExecutionBubble;
+
+        // Execute failure effects if enabled
+        if (effect.runOnFailure && effect.failureEffectList && effect.failureEffectList.list.length > 0) {
+            logger.debug(`Executing failure effect list: bucketId=${request.bucketId} effectCount=${effect.failureEffectList.list.length}`);
+
+            const { outputs = {} } = event ?? {};
+            let clonedOutputs: any;
+            try {
+                clonedOutputs = typeof structuredClone === 'function'
+                    ? structuredClone(outputs)
+                    : JSON.parse(JSON.stringify(outputs));
+            } catch (cloneError) {
+                logger.warn(`Failed to clone outputs for failure effect list: ${String(cloneError)}. Using original outputs.`);
+                clonedOutputs = outputs;
+            }
+
+            try {
+                const effectListResult = await firebot.modules.effectRunner.processEffects({
+                    trigger: event.trigger,
+                    effects: effect.failureEffectList,
+                    outputs: clonedOutputs
+                } as any);
+
+                // Merge execution settings from failure effects
+                if (effectListResult != null) {
+                    const resultAny = effectListResult as any;
+                    if (resultAny.stopEffectExecution === true) {
+                        logger.debug(`Failure effect list requested to stop execution: bucketId=${request.bucketId}`);
+                        result.execution.stop = true;
+                    }
+                }
+            } catch (error) {
+                logger.error(`Failed to execute failure effect list: ${String(error)}`);
+            }
+        }
 
         // "Rate Limit Exceeded" event
         if (effect.triggerEvent) {


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
Allows user to specify an effect list to run upon a check failure. Particularly handy if the user wants to trigger something quick (e.g. a chat reply) and then exit - this mechanism avoids the need to set up a whole conditional effect chain for that.

### Motivation
<!-- Please describe WHY you are making this change. This may include links to GitHub issues if relevant. -->

### Testing
<!-- Outline any testing you've done for these changes. You may provide screen shots, copy/paste from logs, etc. as evidence. -->
