### PR TITLE
Use standard nodejs fs import

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -4,7 +4,8 @@
 
 | Plugin Version | Firebot Version |
 |---|---|
-| 0.1.0+ | 5.65+ |
+| 0.2.1+ | 5.65 and 5.66 |
+| 0.1.0 - 0.2.0 | 5.65 |
 | 0.0.7 | 5.64 |
 
 ## Installation: Plugin

--- a/doc/upgrading.md
+++ b/doc/upgrading.md
@@ -10,7 +10,8 @@ This plugin uses semantic versioning to indicate compatibility changes.
 
 | Plugin Version | Firebot Version |
 |---|---|
-| 0.1.0+ | 5.65+ |
+| 0.2.1+ | 5.65 and 5.66 |
+| 0.1.0 - 0.2.0 | 5.65 |
 | 0.0.7 | 5.64 |
 
 ## Upgrade Procedure
@@ -23,5 +24,7 @@ This plugin uses semantic versioning to indicate compatibility changes.
 Optional: Delete any older versions of this plugin from your Firebot scripts directory to keep it clean.
 
 ## Upgrade Notes
+
+:fire: **Firebot 5.66**: Supported in plugin version 0.2.1 and later. This version complies with a breaking change to the Firebot custom scripting API.
 
 :fire: **Upgrading to 0.1.0+**: Requires Firebot 5.65 or later. If you are running Firebot 5.64, you must remain on version 0.0.7.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "firebot-rate-limiter",
     "scriptOutputName": "firebot-rate-limiter",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "description": "A rate limiter for Firebot",
     "main": "",
     "scripts": {

--- a/src/backend/approval-service.test.ts
+++ b/src/backend/approval-service.test.ts
@@ -4,6 +4,12 @@ import { BucketData } from "./bucket-data";
 import { BucketService } from "./bucket-service";
 
 // Mock the logger
+jest.mock("node:fs", () => ({
+    existsSync: jest.fn().mockReturnValue(false),
+    readFileSync: jest.fn().mockReturnValue("{}"),
+    writeFileSync: jest.fn()
+}));
+
 jest.mock("../main", () => ({
     logger: {
         debug: jest.fn(),
@@ -13,11 +19,6 @@ jest.mock("../main", () => ({
     },
     firebot: {
         modules: {
-            fs: {
-                existsSync: jest.fn().mockReturnValue(false),
-                readFileSync: jest.fn().mockReturnValue("{}"),
-                writeFileSync: jest.fn()
-            },
             frontendCommunicator: {
                 on: jest.fn(),
                 send: jest.fn()

--- a/src/backend/bucket-data.test.ts
+++ b/src/backend/bucket-data.test.ts
@@ -1,14 +1,15 @@
 import { Bucket, BucketDataEntry, CheckRateLimitRequest, RejectReason } from "../shared/types";
 import { BucketData } from "./bucket-data";
 
+jest.mock("node:fs", () => ({
+    existsSync: jest.fn(),
+    readFileSync: jest.fn(),
+    writeFileSync: jest.fn()
+}));
+
 jest.mock("../main", () => ({
     firebot: {
         modules: {
-            fs: {
-                existsSync: jest.fn(),
-                readFileSync: jest.fn(),
-                writeFileSync: jest.fn()
-            },
             frontendCommunicator: {
                 on: jest.fn(),
                 send: jest.fn()
@@ -62,8 +63,8 @@ describe("BucketData", () => {
     const mockedBucketService = require("./bucket-service").bucketService;
     beforeEach(() => {
         jest.useFakeTimers().setSystemTime(now);
-        (require("../main").firebot.modules.fs.existsSync as jest.Mock).mockReturnValue(false);
-        (require("../main").firebot.modules.fs.readFileSync as jest.Mock).mockReturnValue("{}");
+        (require("node:fs").existsSync as jest.Mock).mockReturnValue(false);
+        (require("node:fs").readFileSync as jest.Mock).mockReturnValue("{}");
         mockedBucketService.__setBuckets({
             [bucketId]: bucket
         });

--- a/src/backend/bucket-data.ts
+++ b/src/backend/bucket-data.ts
@@ -1,3 +1,4 @@
+import * as fs from "node:fs";
 import { FrontendCommunicator } from "@crowbartools/firebot-custom-scripts-types/types/modules/frontend-communicator";
 import { firebot, logger } from "../main";
 import {
@@ -357,7 +358,6 @@ export class BucketData {
 
     private loadBucketDataFromFile(): Record<string, BucketDataObject> {
         try {
-            const { fs } = firebot.modules;
             if (!fs.existsSync(this.filePath)) {
                 this.saveBucketDataToFile({});
             }
@@ -399,7 +399,6 @@ export class BucketData {
 
     private saveBucketDataToFile(data: Record<string, BucketDataObject>): void {
         try {
-            const { fs } = firebot.modules;
             const jsonData = JSON.stringify(data, null, 2);
             fs.writeFileSync(this.filePath, jsonData, "utf-8");
         } catch (error) {

--- a/src/backend/bucket-service.test.ts
+++ b/src/backend/bucket-service.test.ts
@@ -4,14 +4,15 @@ import { firebot, logger } from "../main";
 import { Bucket } from "../shared/types";
 import { BucketService, bucketService, initializeBucketService } from "./bucket-service";
 
+jest.mock("node:fs", () => ({
+    existsSync: jest.fn(),
+    readFileSync: jest.fn(),
+    writeFileSync: jest.fn()
+}));
+
 jest.mock("../main", () => ({
     firebot: {
         modules: {
-            fs: {
-                existsSync: jest.fn(),
-                readFileSync: jest.fn(),
-                writeFileSync: jest.fn()
-            },
             frontendCommunicator: {
                 on: jest.fn(),
                 send: jest.fn()
@@ -48,8 +49,8 @@ describe("BucketService", () => {
 
     beforeEach(() => {
         jest.clearAllMocks();
-        (firebot.modules.fs.existsSync as jest.Mock).mockReturnValue(false);
-        (firebot.modules.fs.readFileSync as jest.Mock).mockReturnValue("{}");
+        (require("node:fs").existsSync as jest.Mock).mockReturnValue(false);
+        (require("node:fs").readFileSync as jest.Mock).mockReturnValue("{}");
         service = new BucketService();
     });
 
@@ -59,8 +60,8 @@ describe("BucketService", () => {
     });
 
     it("should save and load buckets from file", () => {
-        (firebot.modules.fs.existsSync as jest.Mock).mockReturnValue(true);
-        (firebot.modules.fs.readFileSync as jest.Mock).mockReturnValue(JSON.stringify({ [bucketId]: bucket }));
+        (require("node:fs").existsSync as jest.Mock).mockReturnValue(true);
+        (require("node:fs").readFileSync as jest.Mock).mockReturnValue(JSON.stringify({ [bucketId]: bucket }));
         service = new BucketService();
         expect(service.getBuckets()[bucketId]).toEqual(bucket);
     });
@@ -68,7 +69,7 @@ describe("BucketService", () => {
     it("should save a bucket and persist to file", () => {
         service["saveBucket"](bucketId, { ...bucket });
         expect(service.getBuckets()[bucketId]).toEqual(expect.objectContaining(bucket));
-        expect(firebot.modules.fs.writeFileSync).toHaveBeenCalled();
+        expect(require("node:fs").writeFileSync).toHaveBeenCalled();
         expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("Updated bucket"));
     });
 
@@ -189,8 +190,8 @@ describe("BucketService", () => {
     });
 
     it("should handle file read error gracefully", () => {
-        (firebot.modules.fs.existsSync as jest.Mock).mockReturnValue(true);
-        (firebot.modules.fs.readFileSync as jest.Mock).mockImplementation(() => {
+        (require("node:fs").existsSync as jest.Mock).mockReturnValue(true);
+        (require("node:fs").readFileSync as jest.Mock).mockImplementation(() => {
             throw new Error("fail");
         });
         service = new BucketService();

--- a/src/backend/bucket-service.ts
+++ b/src/backend/bucket-service.ts
@@ -1,3 +1,4 @@
+import * as fs from "node:fs";
 import { FrontendCommunicator } from "@crowbartools/firebot-custom-scripts-types/types/modules/frontend-communicator";
 import { firebot, logger } from "../main";
 import { Bucket, BucketWithId, DeleteBucketResponse, GetBucketResponse, GetBucketsAsArrayResponse, GetBucketsResponse, InstantiateBucketParameters, SaveBucketResponse } from "../shared/types";
@@ -165,7 +166,6 @@ export class BucketService {
 
     private loadBucketsFromFile(): void {
         try {
-            const fs = firebot.modules.fs;
             if (fs.existsSync(this.filePath)) {
                 const data = fs.readFileSync(this.filePath, "utf8");
                 const parsed = JSON.parse(data);
@@ -183,7 +183,6 @@ export class BucketService {
     }
 
     private saveBucketsToFile(): void {
-        const fs = firebot.modules.fs;
         fs.writeFileSync(this.filePath, JSON.stringify(this.buckets, null, 2));
         logger.debug(`Saved ${Object.keys(this.buckets).length} buckets to ${this.filePath}`);
     }

--- a/src/backend/util.ts
+++ b/src/backend/util.ts
@@ -1,7 +1,8 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
 import { firebot } from "../main";
 
 export function getDataFilePath(filename: string): string {
-    const { fs, path } = firebot.modules;
     const { scriptDataDir } = firebot;
     if (!fs.existsSync(scriptDataDir)) {
         fs.mkdirSync(scriptDataDir, { recursive: true });

--- a/src/effects/check.test.ts
+++ b/src/effects/check.test.ts
@@ -5,6 +5,12 @@ import { CheckRateLimitRequest } from "../shared/types";
 import { checkEffect } from "./check";
 
 // Mock the logger to avoid actual logging during tests
+jest.mock("node:fs", () => ({
+    existsSync: jest.fn().mockReturnValue(false),
+    readFileSync: jest.fn().mockReturnValue("{}"),
+    writeFileSync: jest.fn()
+}));
+
 jest.mock("../main", () => ({
     logger: {
         debug: jest.fn(),
@@ -31,11 +37,6 @@ jest.mock("../main", () => ({
                 channelRewards: {
                     approveOrRejectChannelRewardRedemption: jest.fn()
                 }
-            },
-            fs: {
-                existsSync: jest.fn().mockReturnValue(false),
-                readFileSync: jest.fn().mockReturnValue("{}"),
-                writeFileSync: jest.fn()
             },
             frontendCommunicator: {
                 on: jest.fn(),

--- a/src/effects/undo.test.ts
+++ b/src/effects/undo.test.ts
@@ -5,6 +5,12 @@ import { ApprovalService } from "../backend/approval-service";
 import { undoEffect } from "./undo";
 
 // Mock the logger and approval service
+jest.mock("node:fs", () => ({
+    existsSync: jest.fn().mockReturnValue(false),
+    readFileSync: jest.fn().mockReturnValue("{}"),
+    writeFileSync: jest.fn()
+}));
+
 jest.mock("../main", () => ({
     logger: {
         debug: jest.fn(),
@@ -17,11 +23,6 @@ jest.mock("../main", () => ({
     },
     firebot: {
         modules: {
-            fs: {
-                existsSync: jest.fn().mockReturnValue(false),
-                readFileSync: jest.fn().mockReturnValue("{}"),
-                writeFileSync: jest.fn()
-            },
             frontendCommunicator: {
                 on: jest.fn(),
                 send: jest.fn()

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,7 +23,7 @@ function initializeApprovalService(): void {
     }
 }
 
-const scriptVersion = "0.2.0";
+const scriptVersion = "0.2.1";
 
 const script: Firebot.CustomScript<ScriptSettings> = {
     getScriptManifest: () => {


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
Use standard NodeJS import for "fs" module instead of custom scripting API in Firebot.

### Motivation
Breaking change, removed "fs" from Firebot custom scripting API.

### Testing
<!-- Outline any testing you've done for these changes. You may provide screen shots, copy/paste from logs, etc. as evidence. -->
